### PR TITLE
Add better type hint support

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include spgci/py.typed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "spgci"
-version = "0.0.50"
+version = "0.0.51"
 description = "SPGCI is an API Client for the S&P Commodity Insights REST API"
 authors = ["S&P Global Commodity Insights <pl_api_support@spglobal.com>"]
 license = "Apache-2.0"

--- a/spgci/auth.py
+++ b/spgci/auth.py
@@ -12,13 +12,30 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from functools import lru_cache
+
 import spgci.config as config
 import requests
 from requests.exceptions import HTTPError, SSLError
 import warnings
 from tenacity import retry, retry_if_exception_type, wait_fixed
 from spgci.exceptions import AuthError, PerSecondLimitError, DailyLimitError
+from typing import TYPE_CHECKING
+
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+    from typing import TypeVar
+
+
+    _CachedFn = TypeVar("_CachedFn", bound=Callable)
+
+    def lru_cache() -> Callable[[_CachedFn], _CachedFn]:
+        """Ensure that the type hints still work after calling the lru_cache decorator."""
+        pass
+
+else:
+    from functools import lru_cache
+
 
 _throttle_retry = retry(
     retry=retry_if_exception_type(PerSecondLimitError), reraise=True, wait=wait_fixed(1)


### PR DESCRIPTION
The package has type hints defined in most places, so this adds the py.typed file to allow mypy to use the type hints in projects using the package.

This also adds some code to ensure that a function using the lru_cache will still have type hints since the original code loses the type hints on the decorated function's parameters.